### PR TITLE
RFC Tidy test pins

### DIFF
--- a/examples/build/board_build_example.py
+++ b/examples/build/board_build_example.py
@@ -10,19 +10,7 @@ import argparse
 import rhea.build as build 
 from rhea.build.boards import get_board
 from rhea.build.boards import get_all_board_names
-#from blink import blinky
-
-# some boards don't have LEDs but they have IO that
-# can drive LEDs.  The following maps the led port 
-# to a set of pins for boards without an led port.
-led_port_pin_map = {
-    'xula':  dict(name='led', pins=(36, 37, 50, 52)),
-    'xula2': dict(name='led', pins=('R7', 'R15', 'R16', 'M15',)),
-    'pone': dict(name='led', pins=(18, 23, 26, 33)),
-    # the de0-cv led port is named "ledr", for the generic testing
-    # add the led port
-    'de0cv': dict(name='led', pins=('AA2', 'AA1', 'W2', 'Y3',))
-}
+from rhea.build.boards import led_port_pin_map
 
 
 def print_board_info(args):
@@ -56,11 +44,9 @@ def build_board(args):
     for bn in boards:        
         brd = get_board(bn)
         if brd in led_port_pin_map:
-            brd.add_port(**led_port_pin_map[brd])
-        # check the board definition has led port, if not add it from 
-        # the board_table
+            brd.add_port_name(**led_port_pin_map[brd])
         ledport = brd.get_port('led')
-        
+
     return
 
         

--- a/examples/build/ex_pone.py
+++ b/examples/build/ex_pone.py
@@ -3,14 +3,14 @@ from pprint import pprint
 
 import rhea.build as build
 from rhea.build.boards import get_board
+from rhea.build.boards import led_port_pin_map
 from blink import blinky
-from board_build_example import led_port_pin_map
 
 
 def run_pone():
     brd = get_board('pone')
     #brd.add_port_name('toggle', 'wingC', 7, drive=6)
-    brd.add_port(**led_port_pin_map['pone'])
+    brd.add_port_name(**led_port_pin_map['pone'])
     flow = build.flow.ISE(brd=brd, top=blinky)
     flow.run()
     info = flow.get_utilization()

--- a/examples/build/ex_xula.py
+++ b/examples/build/ex_xula.py
@@ -3,13 +3,13 @@ from pprint import pprint
 
 import rhea.build as build
 from rhea.build.boards import get_board
+from rhea.build.boards import led_port_pin_map
 from blink import blinky
-from board_build_example import led_port_pin_map
 
 
 def run_xula():
     brd = get_board('xula')
-    brd.add_port(**led_port_pin_map['xula'])
+    brd.add_port_name(**led_port_pin_map['xula'])
     flow = build.flow.ISE(brd=brd, top=blinky)
     flow.run()
     info = flow.get_utilization()
@@ -17,7 +17,7 @@ def run_xula():
 
     # get a board to implement the design on
     brd = get_board('xula2')
-    brd.add_port(**led_port_pin_map['xula2'])
+    brd.add_port_name(**led_port_pin_map['xula2'])
     flow = build.flow.ISE(brd=brd, top=blinky)
     flow.run()
     info = flow.get_utilization()

--- a/examples/build/test_boards.py
+++ b/examples/build/test_boards.py
@@ -10,8 +10,16 @@ import os
 import rhea.build as build
 from rhea.build.boards import get_board
 from rhea.build.boards import get_all_board_names
-from board_build_example import led_port_pin_map
 from blink import blinky
+
+# The following maps pins to use for test output for boards without an led port.
+led_port_pin_map = {
+    'xula': dict(name='led', port='chan', slc=[slice(0,2),slice(3,2)]),
+    'xula2': dict(name='led', port='chan', slc=slice(0,4)),
+    'pone': dict(name='led', port='wingA', slc=slice(0,4)),
+    'de0cv': dict(name='led', port='ledr', slc=slice(0,4))
+}
+
 
 
 def test_boards():
@@ -20,7 +28,7 @@ def test_boards():
         
         # map led port for boards without explicit led pins 
         if bn in led_port_pin_map:
-            brd.add_port(**led_port_pin_map[bn])
+            brd.add_port_name(**led_port_pin_map[bn])
 
         flow = build.flow.Yosys(brd=brd, top=blinky)
         flow.path = os.path.join('output', flow.path)

--- a/rhea/build/_fpga.py
+++ b/rhea/build/_fpga.py
@@ -145,9 +145,18 @@ class _fpga(object):
         if slc is None:
             pins = p.pins
         else:
-            assert isinstance(slc, (slice, int)), \
-                "slice (slc) needs to be None or int/slice"
-            pins = p.pins[slc]
+            if isinstance(slc, (slice, int)):
+                pins = p.pins[slc]
+            elif isinstance(slc, (list,tuple)):
+                pins = []
+                for i in [0,3,]:
+                    if isinstance(i,int):
+                        pins.append(p.pins[i])
+                    else:
+                        pins += list(p.pins[i])
+            else:
+                raise Exception("slc must be an int, a slice, or a list of these")
+
         kws = p.pattr.copy()
         kws.update(pattr)
         self.add_port(name, pins, **kws)


### PR DESCRIPTION
This is a request for comments.

The nonlocality of led_port_pin_map bugged me, so hacked this approach up whilse bored, which adds moves the definitions of test output pins to the board defintions.
