### PR TITLE
Docbug: PULLUP='PULLUP' doesn't work.

### DIFF
--- a/rhea/build/fpga.py
+++ b/rhea/build/fpga.py
@@ -109,7 +109,7 @@ class FPGA(object):
         the pin / signal.
 
         Example: 
-          brd.add_port("gpio", pins=(23,24,25,26,), PULLUP='PULLUP')
+          brd.add_port("gpio", pins=(23,24,25,26,), pullup=True)
 
         It is acceptable to have ports with the same names.
         """


### PR DESCRIPTION
See
https://github.com/cfelton/rhea/blob/master/rhea/build/toolflow/xilinx/ise.py#L64

It is actually waiting for a boolean. Also the lower case matches better
the python conventions so it should be documented as pullup=True