### PR TITLE
Changed uart to use a single external fifobus interface

### DIFF
--- a/docs/source/cores.rst
+++ b/docs/source/cores.rst
@@ -51,6 +51,55 @@ The following is a pictorial of the verification environment .
 For more information on the [fpgalink]() software, firmware, and
 general design information see [makestuff]().
 
+uart
+----
+
+The myHDL implementation of the  Universal Asynchronous 
+Receiver/ Transmitter module
+, which is a standard serial communication module between
+devices. Uses a FIFOBus interface to communicate with other modules 
+externally and also to communicate with other devices. The baudwith 
+of the module can be set by setting the baudwidth parameter. UART
+reads bit-wise starting on a low signal after which a fixed length
+(baudwidth) no of bits can be read, after which the stop high 
+signal is received(transmitted).
+
+.. code-block::python
+
+    from rhea.cores.uart import uartlite
+    from rhea.system import FIFOBus
+
+    # ...
+    # fpgalink interface
+    # si - serial in, so - serial out line
+    fifobu = FIFOBus()
+    uart_inst = uartlite(glbl, fifobus, si, so)
+    
+    #comp is another core component or module
+    comp = comp_inst(...)
+    @always_comb
+    def sync_read()
+        comp.read_line.next = fifobus.read_data
+        comp.read_strobe.next = not fifobus_empty
+        comp.validity_check = fifobus.read_valid
+
+    @always_comb
+    def sync_write()
+        fifobus.write_data.next = comp.write_line
+        fifobus.write.next = comp.write_strobe    
+
+    # ...
+
+
+and so on(look into the examples for more). Note 
+that the serial in/out lines are those from the UART's 
+perspective.
+
+Internally, the UART uses two FIFOBus interfaces for communication
+between the the UART and the actual RX/TX fifos from which the data
+is read.The UART has a uartlite module which instantiates the respective 
+FIFOs and synchronises between the external FIFOBus interface and 
+the interface to the two fifos.
 
 usbp
 ----

--- a/docs/source/cores.rst
+++ b/docs/source/cores.rst
@@ -18,7 +18,7 @@ This is a MyHDL implementation of the HDL for the *fpgalink*
 project.  The fpgalink HDL core can be instantiated into
 a design:
 
-.. code-block::python
+.. code-block:: python
 
     from rhea.cores.usbext import m_fpgalink_fx2
 
@@ -31,7 +31,7 @@ a design:
 For simulation and verification the *fpgalink* interface can be
 stimulated using the FX2 model and high-level access functions:
 
-.. code-block::python
+.. code-block:: python
 
    from rhea.models.usbext import fpgalink_host
    from rhea.cores.usbext import fpgalink
@@ -57,49 +57,13 @@ uart
 The myHDL implementation of the  Universal Asynchronous 
 Receiver/ Transmitter module
 , which is a standard serial communication module between
-devices. Uses a FIFOBus interface to communicate with other modules 
+devices. It uses a FIFOBus interface to communicate with other modules 
 externally and also to communicate with other devices. The baudwith 
 of the module can be set by setting the baudwidth parameter. UART
 reads bit-wise starting on a low signal after which a fixed length
 (baudwidth) no of bits can be read, after which the stop high 
 signal is received(transmitted).
 
-.. code-block::python
-
-    from rhea.cores.uart import uartlite
-    from rhea.system import FIFOBus
-
-    # ...
-    # fpgalink interface
-    # si - serial in, so - serial out line
-    fifobu = FIFOBus()
-    uart_inst = uartlite(glbl, fifobus, si, so)
-    
-    #comp is another core component or module
-    comp = comp_inst(...)
-    @always_comb
-    def sync_read()
-        comp.read_line.next = fifobus.read_data
-        comp.read_strobe.next = not fifobus_empty
-        comp.validity_check = fifobus.read_valid
-
-    @always_comb
-    def sync_write()
-        fifobus.write_data.next = comp.write_line
-        fifobus.write.next = comp.write_strobe    
-
-    # ...
-
-
-and so on(look into the examples for more). Note 
-that the serial in/out lines are those from the UART's 
-perspective.
-
-Internally, the UART uses two FIFOBus interfaces for communication
-between the the UART and the actual RX/TX fifos from which the data
-is read.The UART has a uartlite module which instantiates the respective 
-FIFOs and synchronises between the external FIFOBus interface and 
-the interface to the two fifos.
 
 usbp
 ----

--- a/docs/source/cores/uart.rst
+++ b/docs/source/cores/uart.rst
@@ -11,7 +11,7 @@ reads bit-wise starting on a low signal after which a fixed length
 (baudwidth) no of bits can be read, after which the stop high 
 signal is received(transmitted).
 
-.. code-block::python
+.. code-block:: python
 
     from rhea.cores.uart import uartlite
     from rhea.system import FIFOBus

--- a/docs/source/cores/uart.rst
+++ b/docs/source/cores/uart.rst
@@ -1,0 +1,49 @@
+uart
+----
+
+The myHDL implementation of the  Universal Asynchronous 
+Receiver/ Transmitter module
+, which is a standard serial communication module between
+devices. Uses a FIFOBus interface to communicate with other modules 
+externally and also to communicate with other devices. The baudwith 
+of the module can be set by setting the baudwidth parameter. UART
+reads bit-wise starting on a low signal after which a fixed length
+(baudwidth) no of bits can be read, after which the stop high 
+signal is received(transmitted).
+
+.. code-block::python
+
+    from rhea.cores.uart import uartlite
+    from rhea.system import FIFOBus
+
+    # ...
+    # fpgalink interface
+    # si - serial in, so - serial out line
+    fifobu = FIFOBus()
+    uart_inst = uartlite(glbl, fifobus, si, so)
+    
+    #comp is another core component or module
+    comp = comp_inst(...)
+    @always_comb
+    def sync_read()
+        comp.read_line.next = fifobus.read_data
+        comp.read_strobe.next = not fifobus_empty
+        comp.validity_check = fifobus.read_valid
+
+    @always_comb
+    def sync_write()
+        fifobus.write_data.next = comp.write_line
+        fifobus.write.next = comp.write_strobe    
+
+    # ...
+
+
+and so on(look into the examples for more). Note 
+that the serial in/out lines are those from the UART's 
+perspective.
+
+Internally, the UART uses two FIFOBus interfaces for communication
+between the the UART and the actual RX/TX fifos from which the data
+is read.The UART has a uartlite module which instantiates the respective 
+FIFOs and synchronises between the external FIFOBus interface and 
+the interface to the two fifos.

--- a/examples/boards/atlys/atlys_blinky_host.py
+++ b/examples/boards/atlys/atlys_blinky_host.py
@@ -31,13 +31,14 @@ def atlys_blinky_host(clock, reset, led, sw, pmod,
     # create the interfaces to the UART
     fbustx = FIFOBus(width=8, size=32)
     fbusrx = FIFOBus(width=8, size=32)
+    fbusrtx = FIFOBus(width=8, size=32)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
     cmd_tx = Signal(bool(0))
-    uart_inst = uartlite(glbl, fbustx, fbusrx, uart_rx, cmd_tx)
+    uart_inst = uartlite(glbl, fbusrtx, uart_rx, cmd_tx)
 
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)

--- a/examples/boards/catboard/catboard_blinky_host.py
+++ b/examples/boards/catboard/catboard_blinky_host.py
@@ -28,12 +28,13 @@ def catboard_blinky_host(clock, led, uart_tx, uart_rx):
     # create the interfaces to the UART
     fbustx = FIFOBus(width=8, size=4)
     fbusrx = FIFOBus(width=8, size=4)
+    fbusrtx = FIFOBus(width=8, size=4)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
-    uart_inst = uartlite(glbl, fbustx, fbusrx,
+    uart_inst = uartlite(glbl, fbusrtx,
                          serial_in=uart_rx,
                          serial_out=uart_tx)
 

--- a/examples/boards/icestick/icestick.py
+++ b/examples/boards/icestick/icestick.py
@@ -19,17 +19,15 @@ def icestick(clock, led, pmod, uart_tx, uart_rx):
     gticks = glbl_timer_ticks(glbl, include_seconds=True)
 
     # get interfaces to the UART fifos
-    fbustx = FIFOBus(width=8, size=8)
-    fbusrx = FIFOBus(width=8, size=8)
+    fbusrtx = FIFOBus(width=8, size=8)
 
     # get the UART comm from PC
-    guart = uartlite(glbl, fbustx, fbusrx, uart_tx, uart_rx)
+    guart = uartlite(glbl, fbusrtx, uart_tx, uart_rx)
 
     @always_comb
     def beh_loopback():
-        fbusrx.read.next = not fbusrx.empty
-        fbustx.write.next = not fbusrx.empty
-        fbustx.write_data.next = fbusrx.read_data
+        fbusrtx.write_data.next = fbusrtx.read_data
+        fbusrtx.write.next = (not fbusrtx.full) & fbusrtx.read
 
     lcnt = Signal(modbv(0, min=0, max=4))
 

--- a/examples/boards/icestick/icestick_blinky_host.py
+++ b/examples/boards/icestick/icestick_blinky_host.py
@@ -46,21 +46,8 @@ def icestick_blinky_host(clock, led, pmod, uart_tx, uart_rx,
     # create the UART instance.
     uart_inst = uartlite(glbl, uart_fifo, uart_rx, uart_tx)
     
-    @always_comb
-    def sync_write():
-        # sync between the UART fifo interface serial out
-        # and the command bridge out
-        uart_fifo.write_data.next = fbustx.write_data
-        uart_fifo.write.next = fbustx.write
-        fbustx.full.next = uart_fifo.full
-
-    @always_comb
-    def sync_read():
-        # sync between the UART fifo interface serial in
-        # and the command bridge fifo in
-        fbusrx.read_data.next = uart_fifo.read_data
-        fbusrx.empty.next = uart_fifo.empty
-        fbusrx.read_valid.next = uart_fifo.read_valid
+    #map uart_fifo to separate readpath and writepath
+    assign_rw = uart_fifo.assign_read_write_paths(fbusrx,fbustx)
         
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)
@@ -91,7 +78,7 @@ def icestick_blinky_host(clock, led, pmod, uart_tx, uart_rx,
 
     # @todo: PMOD OLED memmap control
 
-    return (tick_inst, uart_inst,sync_read, sync_write, cmd_inst, 
+    return (tick_inst, uart_inst, assign_rw, cmd_inst, 
             beh_led_control, beh_led_read, beh_assign)
 
 

--- a/examples/boards/icestick/icestick_blinky_host.py
+++ b/examples/boards/icestick/icestick_blinky_host.py
@@ -36,14 +36,15 @@ def icestick_blinky_host(clock, led, pmod, uart_tx, uart_rx,
     tick_inst = glbl_timer_ticks(glbl, include_seconds=True)
 
     # create the interfaces to the UART
-    fbustx = FIFOBus(width=8, size=4)
+    fbusrtx = FIFOBus(width=8, size=4)
     fbusrx = FIFOBus(width=8, size=4)
+    fbusrtx = FIFOBus(width=8, size=4)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
-    uart_inst = uartlite(glbl, fbustx, fbusrx, uart_rx, uart_tx)
+    uart_inst = uartlite(glbl, fbusrtx, uart_rx, uart_tx)
 
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)

--- a/examples/boards/icestick/icestick_blinky_host.py
+++ b/examples/boards/icestick/icestick_blinky_host.py
@@ -36,16 +36,32 @@ def icestick_blinky_host(clock, led, pmod, uart_tx, uart_rx,
     tick_inst = glbl_timer_ticks(glbl, include_seconds=True)
 
     # create the interfaces to the UART
-    fbusrtx = FIFOBus(width=8, size=4)
+    fbustx = FIFOBus(width=8, size=4)
     fbusrx = FIFOBus(width=8, size=4)
-    fbusrtx = FIFOBus(width=8, size=4)
+    uart_fifo = FIFOBus(width=8, size=4)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
-    uart_inst = uartlite(glbl, fbusrtx, uart_rx, uart_tx)
+    uart_inst = uartlite(glbl, uart_fifo, uart_rx, uart_tx)
+    
+    @always_comb
+    def sync_write():
+        # sync between the UART fifo interface serial out
+        # and the command bridge out
+        uart_fifo.write_data.next = fbustx.write_data
+        uart_fifo.write.next = fbustx.write
+        fbustx.full.next = uart_fifo.full
 
+    @always_comb
+    def sync_read():
+        # sync between the UART fifo interface serial in
+        # and the command bridge fifo in
+        fbusrx.read_data.next = uart_fifo.read_data
+        fbusrx.empty.next = uart_fifo.empty
+        fbusrx.read_valid.next = uart_fifo.read_valid
+        
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)
 
@@ -75,7 +91,7 @@ def icestick_blinky_host(clock, led, pmod, uart_tx, uart_rx,
 
     # @todo: PMOD OLED memmap control
 
-    return (tick_inst, uart_inst, cmd_inst, 
+    return (tick_inst, uart_inst,sync_read, sync_write, cmd_inst, 
             beh_led_control, beh_led_read, beh_assign)
 
 

--- a/examples/boards/xula/xula_blinky_host.py
+++ b/examples/boards/xula/xula_blinky_host.py
@@ -29,15 +29,31 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
     # create the interfaces to the UART
     fbustx = FIFOBus(width=8, size=4)
     fbusrx = FIFOBus(width=8, size=4)
-    fbusrtx = FIFOBus(width=8, size=4)
+    uart_fifo = FIFOBus(width=8, size=4)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
-    uart_inst = uartlite(glbl, fbusrtx,
+    uart_inst = uartlite(glbl, uart_fifo,
                          serial_in=bcm14_txd,
                          serial_out=bcm15_rxd)
+
+    @always_comb
+    def sync_write():
+        # sync between the UART fifo interface serial out
+        # and the command bridge out
+        uart_fifo.write_data.next = fbustx.write_data
+        uart_fifo.write.next = fbustx.write
+        fbustx.full.next = uart_fifo.full
+
+    @always_comb
+    def sync_read():
+        # sync between the UART fifo interface serial in
+        # and the command bridge fifo in
+        fbusrx.read_data.next = uart_fifo.read_data
+        fbusrx.empty.next = uart_fifo.empty
+        fbusrx.read_valid.next = uart_fifo.read_valid
 
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)
@@ -64,7 +80,7 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
             tone.next = (~tone) & 0x1
         led.next = ledreg | tone[5:] 
             
-    return (tick_inst, uart_inst, cmd_inst, 
+    return (tick_inst, uart_inst, cmd_inst, sync_read, sync_write,
             beh_led_control, beh_led_read, beh_assign)
 
 

--- a/examples/boards/xula/xula_blinky_host.py
+++ b/examples/boards/xula/xula_blinky_host.py
@@ -29,12 +29,13 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
     # create the interfaces to the UART
     fbustx = FIFOBus(width=8, size=4)
     fbusrx = FIFOBus(width=8, size=4)
+    fbusrtx = FIFOBus(width=8, size=4)
 
     # create the memmap (CSR) interface
     memmap = Barebone(glbl, data_width=32, address_width=32)
 
     # create the UART instance.
-    uart_inst = uartlite(glbl, fbustx, fbusrx,
+    uart_inst = uartlite(glbl, fbusrtx,
                          serial_in=bcm14_txd,
                          serial_out=bcm15_rxd)
 

--- a/examples/boards/xula/xula_blinky_host.py
+++ b/examples/boards/xula/xula_blinky_host.py
@@ -39,21 +39,8 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
                          serial_in=bcm14_txd,
                          serial_out=bcm15_rxd)
 
-    @always_comb
-    def sync_write():
-        # sync between the UART fifo interface serial out
-        # and the command bridge out
-        uart_fifo.write_data.next = fbustx.write_data
-        uart_fifo.write.next = fbustx.write
-        fbustx.full.next = uart_fifo.full
-
-    @always_comb
-    def sync_read():
-        # sync between the UART fifo interface serial in
-        # and the command bridge fifo in
-        fbusrx.read_data.next = uart_fifo.read_data
-        fbusrx.empty.next = uart_fifo.empty
-        fbusrx.read_valid.next = uart_fifo.read_valid
+    #map uart_fifo to separate readpath and writepath
+    assign_rw = uart_fifo.assign_read_write_paths(fbusrx,fbustx)
 
     # create the packet command instance
     cmd_inst = command_bridge(glbl, fbusrx, fbustx, memmap)
@@ -80,7 +67,7 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
             tone.next = (~tone) & 0x1
         led.next = ledreg | tone[5:] 
             
-    return (tick_inst, uart_inst, cmd_inst, sync_read, sync_write,
+    return (tick_inst, uart_inst, cmd_inst, assign_rw,
             beh_led_control, beh_led_read, beh_assign)
 
 

--- a/rhea/cores/uart/uartbase.py
+++ b/rhea/cores/uart/uartbase.py
@@ -10,7 +10,23 @@ from myhdl import (Signal, intbv, modbv, enum, always_seq,
 
 def uartbaud(glbl, baudce, baudce16, baudrate=115200):
     """ Generate the UART baudrate strobe
+
     Three separate strobes are create: baudce, baudceh
+    
+    Arguments:
+        glbl: rhea.Global interface, clk from glbl
+        baudce: The baudce stobe
+        baudce16: The baudce16 strobe
+        Both of these are calculated in the function.
+
+    Parameters:
+        baudrate: The desired baudrate
+
+    Return:
+        myHDL generators
+        rtlbaud: baudce strobe generator
+        rtlbaud16: baudce16 strobe generator
+                         
     """
     clock, reset = glbl.clock, glbl.reset
 
@@ -63,20 +79,17 @@ def uartbaud(glbl, baudce, baudce16, baudrate=115200):
 
 def uarttx(glbl, fbustx, tx, baudce):
     """UART transmitter  function
-       
-    Ports
-    -----
+    
+    Arguments(Ports):
         glbl : rhea.Global interface, clock and reset
         fbustx : FIFOBus interface to the TX fifo
         tx : The actual transmition line
 
-    Parameters
-    ----------
+    Parameters:
         baudce : The transmittion baud rate
 
-    Returns
-    -------
-        myhdl generator
+    Returns:
+        myHDL generator
         rtltx : Generator to keep open the transmittion line 
             and write into it from the TX fifo.
         
@@ -133,19 +146,16 @@ def uarttx(glbl, fbustx, tx, baudce):
 def uartrx(glbl, fbusrx, rx, baudce16):
     """UART receiver function
        
-    Ports
-    -----
+    Arguments(Ports):
         glbl : rhea.Global interface, clock and reset
         fbusrx : FIFOBus interface to the RX fifo
         rx : The actual reciever line
 
-    Parameters
-    ----------
+    Parameters:
         baudce16 : The receive baud rate
 
-    Returns
-    -------
-        myhdl generator
+    Returns:
+        myHDL generators
         rtlmid : Get the mid bits        
         rtlrx : Generator to keep open the receive line 
             and read from it into RX fifo.

--- a/rhea/cores/uart/uartbase.py
+++ b/rhea/cores/uart/uartbase.py
@@ -111,7 +111,8 @@ def uarttx(glbl, fbustx, tx, baudce):
 
     return rtltx
 
-
+# open the receiving line and read into fbusrx bytewise
+# that is, read into rx from fbusrx (receiver bus)
 def uartrx(glbl, fbusrx, rx, baudce16):
     """ """
     clock, reset = glbl.clock, glbl.reset

--- a/rhea/cores/uart/uartbase.py
+++ b/rhea/cores/uart/uartbase.py
@@ -62,7 +62,24 @@ def uartbaud(glbl, baudce, baudce16, baudrate=115200):
 
 
 def uarttx(glbl, fbustx, tx, baudce):
-    """
+    """UART transmitter  function
+       
+    Ports
+    -----
+        glbl : rhea.Global interface, clock and reset
+        fbustx : FIFOBus interface to the TX fifo
+        tx : The actual transmition line
+
+    Parameters
+    ----------
+        baudce : The transmittion baud rate
+
+    Returns
+    -------
+        myhdl generator
+        rtltx : Generator to keep open the transmittion line 
+            and write into it from the TX fifo.
+        
     """
     clock, reset = glbl.clock, glbl.reset
 
@@ -114,7 +131,26 @@ def uarttx(glbl, fbustx, tx, baudce):
 # open the receiving line and read into fbusrx bytewise
 # that is, read into rx from fbusrx (receiver bus)
 def uartrx(glbl, fbusrx, rx, baudce16):
-    """ """
+    """UART receiver function
+       
+    Ports
+    -----
+        glbl : rhea.Global interface, clock and reset
+        fbusrx : FIFOBus interface to the RX fifo
+        rx : The actual reciever line
+
+    Parameters
+    ----------
+        baudce16 : The receive baud rate
+
+    Returns
+    -------
+        myhdl generator
+        rtlmid : Get the mid bits        
+        rtlrx : Generator to keep open the receive line 
+            and read from it into RX fifo.
+        
+    """
     clock, reset = glbl.clock, glbl.reset
 
     states = enum('wait', 'byte', 'stop', 'end')

--- a/rhea/cores/uart/uartlite.py
+++ b/rhea/cores/uart/uartlite.py
@@ -9,25 +9,21 @@ from rhea.system import FIFOBus
 def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
     """ The top-level for a minimal fixed baud UART
 
-    The UART has one external FIFOBus interface and two internal
-    ones to the specific RX/TX fifos. It is through the internal fbusrx,fbustx
-    FIFOBus interfaces that the UART reads into/writes from the RX/TX fifo queues
-    respectively.
+    The function instantiates the various components required for
+    the UART. Uses an external FIFOBus interface to communicate 
+    with other modules(provide the r/w stobe, data etc.).
 
-    Ports
-    -----
+    Arguments(Ports):
         glbl: rhea.Global interface, clock and reset from glbl
         fbustx: The transmit FIFO bus, interface to the TX FIFO (see fifo_fast.py)
         tbusrx: The receive FIFObus, interface to the RX FIFO
         serial_in: The UART external serial line in
         serial_out: The UART external serial line out
 
-    Parameters
-    ----------
+    Parameters:
         baudrate: the desired baudrate for the UART
 
-    Returns
-    -------
+    Returns:
         myhdl generators
         instsyncrx, instsynctx : syncs of external r/w line to the internal r/t
         insttxfifo, instrxfifo : The actual TX and RX fifos
@@ -63,8 +59,8 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
     # for transmitting and receiving
 
     @always_comb
-    def sync_read():
-        """Sync external UART FIFOBus interface attribs with internal RX FIFO interface.
+    def assign_read():
+        """Map external UART FIFOBus interface attribs with internal RX FIFO interface.
       
         """
         # fifobus.read_data is the channel that the UART 
@@ -79,8 +75,8 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
         fifobus.read_valid.next = fbusrx.read_valid
 
     @always_comb
-    def sync_write():
-        """Sync external UART FIFOBus interface attribs with internal TX FIFO interface.
+    def assign_write():
+        """Map external UART FIFOBus interface attribs with internal TX FIFO interface.
 
         """
         # queue to TX fifo whenever given ext. strobe

--- a/rhea/cores/uart/uartlite.py
+++ b/rhea/cores/uart/uartlite.py
@@ -11,19 +11,24 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     Ports
     -----
-    glbl: rhea.Global interface, clock and reset from glbl
-    fbustx: The transmit FIFO bus, interface to the TX FIFO (see fifo_fast.py)
-    tbusrx: The receive FIFObus, interface to the RX FIFO
-    serial_in: The UART external serial line in
-    serial_out: The UART external serial line out
+        glbl: rhea.Global interface, clock and reset from glbl
+        fbustx: The transmit FIFO bus, interface to the TX FIFO (see fifo_fast.py)
+        tbusrx: The receive FIFObus, interface to the RX FIFO
+        serial_in: The UART external serial line in
+        serial_out: The UART external serial line out
 
     Parameters
     ----------
-    baudrate: the desired baudrate for the UART
+        baudrate: the desired baudrate for the UART
 
     Returns
     -------
-    myhdl generators
+        myhdl generators
+        instsyncrx, instsynctx : syncs of external r/w line to the internal r/t
+        insttxfifo, instrxfifo : The actual TX and RX fifos
+        instbaud : baud strobe instantiation
+        insttx, instrx : uart tx and rx generators
+        sync_read,sync_write : convert one ext. Fbus to dual, for r/w
 
     This module is myhdl convertible
     """
@@ -54,6 +59,9 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     @always_comb
     def sync_read():
+        # fifobus.read_data is the channel that the UART 
+        # reads data on and fifobus.write_data is the one 
+        # it writes to.
         # read into the fifobus from the RX fifo queue 
         # whenever available by ckecking the queue
         fifobus.empty.next = fbusrx.empty

--- a/rhea/cores/uart/uartlite.py
+++ b/rhea/cores/uart/uartlite.py
@@ -9,6 +9,11 @@ from rhea.system import FIFOBus
 def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
     """ The top-level for a minimal fixed baud UART
 
+    The UART has one external FIFOBus interface and two internal
+    ones to the specific RX/TX fifos. It is through the internal fbusrx,fbustx
+    FIFOBus interfaces that the UART reads into/writes from the RX/TX fifo queues
+    respectively.
+
     Ports
     -----
         glbl: rhea.Global interface, clock and reset from glbl
@@ -59,6 +64,9 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     @always_comb
     def sync_read():
+    """Sync external UART FIFOBus interface attribs with internal RX FIFO interface.
+      
+    """
         # fifobus.read_data is the channel that the UART 
         # reads data on and fifobus.write_data is the one 
         # it writes to.
@@ -72,6 +80,9 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     @always_comb
     def sync_write():
+    """Sync external UART FIFOBus interface attribs with internal TX FIFO interface.
+
+    """
         # queue to TX fifo whenever given ext. strobe
         # which will auto. be transferred by uarttx()
         fifobus.full.next = fbustx.full

--- a/rhea/cores/uart/uartlite.py
+++ b/rhea/cores/uart/uartlite.py
@@ -64,9 +64,9 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     @always_comb
     def sync_read():
-    """Sync external UART FIFOBus interface attribs with internal RX FIFO interface.
+        """Sync external UART FIFOBus interface attribs with internal RX FIFO interface.
       
-    """
+        """
         # fifobus.read_data is the channel that the UART 
         # reads data on and fifobus.write_data is the one 
         # it writes to.
@@ -80,9 +80,9 @@ def uartlite(glbl, fifobus, serial_in, serial_out, baudrate=115200):
 
     @always_comb
     def sync_write():
-    """Sync external UART FIFOBus interface attribs with internal TX FIFO interface.
+        """Sync external UART FIFOBus interface attribs with internal TX FIFO interface.
 
-    """
+        """
         # queue to TX fifo whenever given ext. strobe
         # which will auto. be transferred by uarttx()
         fifobus.full.next = fbustx.full

--- a/rhea/system/stream/fifobus.py
+++ b/rhea/system/stream/fifobus.py
@@ -28,7 +28,8 @@ class FIFOBus(object):
         # @todo: write, write_data, etc.!
 
         # all the data signals are from the perspective
-        # of the FIFO being interfaced to.        
+        # of the FIFO being interfaced to. That is , write_data
+        # means write_to and read_data means read_from      
         self.clear = Signal(bool(0))           # fifo clear
         #self.wclk = None                      # write side clock
         self.write = Signal(bool(0))              # write strobe to fifo

--- a/rhea/system/stream/fifobus.py
+++ b/rhea/system/stream/fifobus.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2013-2015 Christopher L. Felton
 #
 
-from myhdl import Signal, intbv
+from myhdl import Signal, intbv, always_comb
 
 
 _fb_num = 0
@@ -59,6 +59,28 @@ class FIFOBus(object):
 
     def readtrans(self):
         pass
+
+    def assign_read_write_paths(self, readpath, writepath):
+        """
+        Assign the signals from the `readpath` to the read signals
+        of this interface and same for write
+        """
+        assert isinstance(readpath, FIFOBus)
+        assert isinstance(writepath, FIFOBus)
+        
+        @always_comb
+        def beh_assign():
+            # read
+            readpath.read_data.next = self.read_data
+            readpath.empty.next = self.empty
+            readpath.read_valid.next = self.read_valid
+            
+            # write           
+            self.write_data.next = writepath.write_data
+            self.write.next = writepath.write
+            writepath.full.next = self.full
+           
+        return beh_assign
 
     # @todo: get the separate buses
     # def get_upstream()    

--- a/test/test_cores/test_uart.py
+++ b/test/test_cores/test_uart.py
@@ -15,7 +15,6 @@ from rhea.system import FIFOBus
 
 from rhea.utils.test import run_testbench, tb_args
 
-
 def testbench_uart_model(args=None):
     # @todo: get numbytes from args
     numbytes = 7
@@ -63,7 +62,7 @@ def testbench_uart_model(args=None):
     run_testbench(_bench_uart_model, args=args)
 
 
-@pytest.mark.skipif(True, reason="pytest issue/error 10x runtime")
+#@pytest.mark.skipif(True, reason="pytest issue/error 10x runtime")
 def testbench_uart(args=None):
     # @todo: get numbytes from args
     numbytes = 13
@@ -72,19 +71,18 @@ def testbench_uart(args=None):
     glbl = Global(clock, reset)
     mdlsi, mdlso = Signal(bool(1)), Signal(bool(1))
     uartmdl = UARTModel()
-    fifotx = FIFOBus()
-    fiforx = FIFOBus()
+    fifortx = FIFOBus()
 
     def _bench_uart():
         tbmdl = uartmdl.process(glbl, mdlsi, mdlso)
-        tbdut = uartlite(glbl, fifotx, fiforx, mdlso, mdlsi)
+        tbdut = uartlite(glbl, fifortx, mdlso, mdlsi)
         tbclk = clock.gen()
 
         @always_comb
         def tblpbk():
-            fifotx.write_data.next = fiforx.read_data
-            fifotx.write.next = not fiforx.empty
-            fiforx.read.next = not fiforx.empty
+            fifortx.write_data.next = fifortx.read_data
+            fifortx.write.next = (not fifortx.full) & fifortx.read
+           
 
         @instance
         def tbstim():
@@ -112,7 +110,7 @@ def testbench_uart(args=None):
             raise StopSimulation
 
         return tbdut, tbmdl, tbclk, tblpbk, tbstim
-
+ 
     run_testbench(_bench_uart, args=args)
 
 


### PR DESCRIPTION
The uartlite module has been modified to use a single external fifobus interface, while still using different RX fifo and TX fifo internally.