### PR TITLE
Renamed async to isasync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
+dist: xenial
 
 language: python
 python:
+  - "3.7"
   - "3.5"
   - "3.4"
   - "2.7"

--- a/docs/source/base_building_blocks.rst
+++ b/docs/source/base_building_blocks.rst
@@ -14,7 +14,7 @@ The following is the list of the functions and objects in the rhea
 top-level namespace.  See the information below for more details.
 
    #. rhea.Clock(init_val, frequency)
-   #. rhea.Reset(init_val, active, async)
+   #. rhea.Reset(init_val, active, isasync)
    #. rhea.Global()
    #. rhea.Constants(**named_constants)
    #. rhea.Signals(sigtype, num_sigs)

--- a/examples/boards/atlys/test_atlys_blinky_host.py
+++ b/examples/boards/atlys/test_atlys_blinky_host.py
@@ -20,7 +20,7 @@ def test_ibh(args=None):
     numbytes = 13
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     glbl = Global(clock, reset)
     led = Signal(intbv(0)[8:])
     sw = Signal(intbv(1)[8:])

--- a/examples/boards/de0nano/button_led/test.py
+++ b/examples/boards/de0nano/button_led/test.py
@@ -16,7 +16,7 @@ from rhea.utils.test import run_testbench
 def test_btn_led():
 
     clock = Clock(0, frequency=500e3)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     leds = Signal(intbv(0)[8:])
     btns = Signal(intbv(0)[4:])
 

--- a/examples/boards/de0nano/converters/de0nano_converters.py
+++ b/examples/boards/de0nano/converters/de0nano_converters.py
@@ -102,7 +102,7 @@ def de0nano_converters(clock, reset, led,
 #        portmap = brd.map_ports(de0nano_converters)
 de0nano_converters.portmap = {
     'clock': Clock(0, frequency=50e6),
-    'reset': Reset(0, active=0, async=True),
+    'reset': Reset(0, active=0, isasync=True),
     'led': Signal(intbv(0)[8:]),
     'adc_cs_n': Signal(bool(1)),
     'adc_saddr': Signal(bool(1)),

--- a/examples/boards/de0nano/lt24lcd/de0nano_lt24lcd.py
+++ b/examples/boards/de0nano/lt24lcd/de0nano_lt24lcd.py
@@ -73,7 +73,7 @@ def de0nano_lt24lcd(clock, reset, led,
 #        portmap = brd.map_ports(de0nano_converters)
 de0nano_lt24lcd.portmap = {
     'clock': Clock(0, frequency=50e6),
-    'reset': Reset(0, active=0, async=True),
+    'reset': Reset(0, active=0, isasync=True),
     'led': Signal(intbv(0)[8:]),
     'lcd_on': Signal(bool(1)),
     'lcd_resetn': Signal(bool(1)),

--- a/examples/boards/de0nano_soc/device_primitives/de0nano_soc_device_prims.py
+++ b/examples/boards/de0nano_soc/device_primitives/de0nano_soc_device_prims.py
@@ -68,7 +68,7 @@ def de0nano_soc_device_prims(clock, reset, led):
 def test_devprim(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     led = Signal(intbv(0))
 
     @myhdl.block

--- a/examples/boards/nexys/fpgalink/fpgalink.py
+++ b/examples/boards/nexys/fpgalink/fpgalink.py
@@ -99,7 +99,7 @@ def convert():
     FLAGA,FLAGB,FLAGC,FLAGD = [Signal(bool(0)) for _ in range(4)]
     ADDR = Signal(intbv(0)[2:])
     IFCLK = Signal(bool(0))
-    RST = ResetSignal(bool(1), active=0, async=True)
+    RST = ResetSignal(bool(1), active=0, isasync=True)
     LEDS = Signal(intbv(0)[8:])
     PKTEND = Signal(bool(0))
 

--- a/examples/boards/papilio_pro/uart_blinky.py
+++ b/examples/boards/papilio_pro/uart_blinky.py
@@ -26,7 +26,7 @@ def uart_blinky(clock, led, uart_tx, uart_rx):
     For details about the message format see
     /rhea/cores/memmap/command_bridge.py
     """
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     glbl = Global(clock, reset)
     ledreg = Signal(intbv(0)[8:])

--- a/examples/boards/parallella/test_serdes/parallella_serdes.py
+++ b/examples/boards/parallella/test_serdes/parallella_serdes.py
@@ -80,7 +80,7 @@ def build(args):
     # @todo: use parallella board, use an ISE support board for now ...
     brd = get_board('parallella')
     # @todo: temporary for existing board
-    # brd.add_reset('reset', active=1, async=True, pins=('N20',))
+    # brd.add_reset('reset', active=1, isasync=True, pins=('N20',))
     brd.add_port_name('serial_tx_p', 'gpio_p', slice(4, 8))
     brd.add_port_name('serial_tx_n', 'gpio_n', slice(4, 8))
     brd.add_port_name('serial_rx_p', 'gpio_p', slice(8, 12))

--- a/examples/boards/parallella/test_serdes/test_parallella_serdes.py
+++ b/examples/boards/parallella/test_serdes/test_parallella_serdes.py
@@ -18,7 +18,7 @@ def test_parallella_serdes(args=None):
     args = tb_default_args(args)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=True)
+    reset = Reset(0, active=1, isasync=True)
     txp = Signal(intbv(0)[6:])
     txn = Signal(intbv(0)[6:])
     rxp = Signal(intbv(0)[6:])

--- a/examples/boards/xula/vga/test_xula_vga.py
+++ b/examples/boards/xula/vga/test_xula_vga.py
@@ -22,7 +22,7 @@ def test_xula_vga(args=None):
     color_depth = (3, 4, 3,)
 
     clock = Clock(0, frequency=12e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     vga = VGA(color_depth=color_depth)
     vga_hsync, vga_vsync = Signals(bool(0), 2)

--- a/examples/boards/xula/vga/xula_vga.py
+++ b/examples/boards/xula/vga/xula_vga.py
@@ -38,7 +38,7 @@ def xula_vga(
     """
     # stub out reset if needed
     if reset is None:
-        reset = ResetSignal(0, active=0, async=False)
+        reset = ResetSignal(0, active=0, isasync=False)
 
         @always(clock.posedge)
         def reset_stub():
@@ -75,7 +75,7 @@ def convert(color_depth=(10, 10, 10,)):
     """ convert the vgasys to verilog
     """
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     vselect = Signal(bool(0))
 
     hsync = Signal(bool(0))

--- a/examples/boards/xula/xula_blinky_host.py
+++ b/examples/boards/xula/xula_blinky_host.py
@@ -70,7 +70,7 @@ def xula2_blinky_host(clock, reset, led, bcm14_txd, bcm15_rxd):
 def build(args):
     brd = get_board('xula2_stickit_mb')
     brd.add_port_name('led', 'pm2', slice(0, 8))
-    brd.add_reset('reset', active=0, async=True, pins=('H2',))
+    brd.add_reset('reset', active=0, isasync=True, pins=('H2',))
     flow = brd.get_flow(top=xula2_blinky_host)
     flow.run()
     info = flow.get_utilization()

--- a/examples/boards/zybo/device_primitives/test.py
+++ b/examples/boards/zybo/device_primitives/test.py
@@ -12,7 +12,7 @@ from zybo_device_primitives import zybo_device_prim
 def test_devprim(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     leds = Signal(intbv(0)[4:])
 
     @myhdl.block

--- a/examples/build/blink.py
+++ b/examples/build/blink.py
@@ -30,7 +30,7 @@ def blinky(led, clock, reset=None):
             led.next[ii] = 0
         
     if reset is None:
-        reset = ResetSignal(0, active=0, async=False)
+        reset = ResetSignal(0, active=0, isasync=False)
 
         @always(clock.posedge)
         def rtl_reset():

--- a/examples/cores/fifo36/ex_fifo36.py
+++ b/examples/cores/fifo36/ex_fifo36.py
@@ -120,7 +120,7 @@ def convert(args=None):
     dst_rdy_i = Signal(bool(0))
     occupied = Signal(intbv(0)[16:])
 
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
 
     inst = fifo_2clock_cascade(
         wclk, datain, src_rdy_i, dst_rdy_o, space,

--- a/examples/cores/fpgalink/led/fpgalink_led.py
+++ b/examples/cores/fpgalink/led/fpgalink_led.py
@@ -88,7 +88,7 @@ def convert():
     FLAGA,FLAGB,FLAGC,FLAGD = [Signal(bool(0)) for ii in range(4)]
     ADDR = Signal(intbv(0)[2:])
     IFCLK = Signal(bool(0))
-    RST = ResetSignal(bool(1), active=0, async=True)
+    RST = ResetSignal(bool(1), active=0, isasync=True)
     LEDS = Signal(intbv(0)[8:])
     PKTEND = Signal(bool(0))
 

--- a/examples/cores/fpgalink/led/fpgalink_led_tri.py
+++ b/examples/cores/fpgalink/led/fpgalink_led_tri.py
@@ -106,7 +106,7 @@ def convert():
     FLAGA,FLAGB,FLAGC,FLAGD = [Signal(bool(0)) for ii in range(4)]
     ADDR = Signal(intbv(0)[2:])
     IFCLK = Signal(bool(0))
-    RST = ResetSignal(bool(1), active=0, async=True)
+    RST = ResetSignal(bool(1), active=0, isasync=True)
     leds = Signal(intbv(0)[8:])
     PKTEND = Signal(bool(0))
 

--- a/rhea/build/boards/altera/de0cv.py
+++ b/rhea/build/boards/altera/de0cv.py
@@ -26,7 +26,7 @@ class DE0CV(FPGA):
     }
 
     default_resets = {
-        'reset': dict(active=0, async=True, pins=('P22',))
+        'reset': dict(active=0, isasync=True, pins=('P22',))
     }
 
     default_ports = {

--- a/rhea/build/boards/altera/de0nano.py
+++ b/rhea/build/boards/altera/de0nano.py
@@ -23,7 +23,7 @@ class DE0Nano(FPGA):
     }
 
     default_resets = {
-        'reset': dict(active=0, async=True, pins=('J15',))
+        'reset': dict(active=0, isasync=True, pins=('J15',))
     }
     
     default_ports = {

--- a/rhea/build/boards/altera/de0nano_soc.py
+++ b/rhea/build/boards/altera/de0nano_soc.py
@@ -26,9 +26,9 @@ class DE0NanoSOC(FPGA):
     }
 
     default_resets = {
-        'reset': dict(active=0, async=True, pins=('AH16',))
+        'reset': dict(active=0, isasync=True, pins=('AH16',))
     }
-    
+
     default_ports = {
         'led': dict(pins=('W15', 'AA24', 'V16', 'V15',
                           'AF26', 'AE26', 'Y16', 'AA23',)),

--- a/rhea/build/boards/altera/de1_soc.py
+++ b/rhea/build/boards/altera/de1_soc.py
@@ -33,9 +33,9 @@ class DE1SOC(FPGA):
     default_resets = {
         # if an external reset is desired push button 0 (key0)
         # can be used.  Note this overlaps with "key[0]"
-        'reset': dict(active=0, async=True, pins=('AA14',))
+        'reset': dict(active=0, isasync=True, pins=('AA14',))
     }
-    
+
     default_ports = {
         'led': dict(pins=('V16', 'W16', 'V17', 'V18', 'W17',
                           'W19', 'Y19', 'W20', 'W21', 'Y21')),

--- a/rhea/build/boards/xilinx/_atlys.py
+++ b/rhea/build/boards/xilinx/_atlys.py
@@ -17,7 +17,7 @@ class Atlys(FPGA):
     }
 
     default_resets = {
-        'reset': dict(active=0, async=True, pins=('T15',)),
+        'reset': dict(active=0, isasync=True, pins=('T15',)),
     }
     
     default_ports = {

--- a/rhea/build/boards/xilinx/_mojo.py
+++ b/rhea/build/boards/xilinx/_mojo.py
@@ -27,7 +27,7 @@ class Mojo(FPGA):
 
     default_resets = {
         # rst_n in documentation
-        'reset': dict(active=0, async=True, pins=(38,),
+        'reset': dict(active=0, isasync=True, pins=(38,),
                       iostandard='LVTTL')
     }
     

--- a/rhea/build/boards/xilinx/_sx1.py
+++ b/rhea/build/boards/xilinx/_sx1.py
@@ -14,11 +14,11 @@ class SX1(FPGA):
     default_clocks = {
         'clock': dict(frequency=48e6, pins=(35,)),
     }
-    
+
     default_resets = {
-        'reset': dict(active=0, async=True, pins=(13,)),    
+        'reset': dict(active=0, isasync=True, pins=(13,)),
     }
-    
+
     default_ports = {
         'led': dict(pins=(90, 91, 92, 94, 95, 96, 99)),
                          

--- a/rhea/build/boards/xilinx/_ufo400.py
+++ b/rhea/build/boards/xilinx/_ufo400.py
@@ -16,7 +16,7 @@ class UFO400(FPGA):
     }
     
     default_resets = {
-        'reset': dict(active=0, async=True, pins=(8,)),    
+        'reset': dict(active=0, isasync=True, pins=(8,)),
     }
     
     default_ports = {

--- a/rhea/build/boards/xilinx/_xupv2p.py
+++ b/rhea/build/boards/xilinx/_xupv2p.py
@@ -15,7 +15,7 @@ class XUPV2P(FPGA):
     }
     
     default_resets = {
-        'reset': dict(active=0, async=True, pins=('AH5',)),    
+        'reset': dict(active=0, isasync=True, pins=('AH5',)),
     }
     
     default_ports = {

--- a/rhea/build/boards/xilinx/zybo.py
+++ b/rhea/build/boards/xilinx/zybo.py
@@ -17,7 +17,7 @@ class Zybo(FPGA):
     }
 
     # default_resets = {
-    #     'reset': dict(active=0, async=True, pins=('G14',),
+    #     'reset': dict(active=0, isasync=True, pins=('G14',),
     #                   iostandard='LVCMOS25'),  #  drive=4
     # }
     

--- a/rhea/build/fpga.py
+++ b/rhea/build/fpga.py
@@ -92,11 +92,11 @@ class FPGA(object):
         self._clocks[name] = p
         self._ports[name] = p
 
-    def add_reset(self, name, active, async, pins, **pattr):
-        assert isinstance(async, bool)
+    def add_reset(self, name, active, isasync, pins, **pattr):
+        assert isinstance(isasync, bool)
         assert active in (0,1,)
-        p = Port(name, pins, 
-                 sigtype=Reset(0, active=active, async=async), **pattr)
+        p = Port(name, pins,
+                 sigtype=Reset(0, active=active, isasync=isasync), **pattr)
         # add to the reset and port dicts
         self._resets[name] = p
         self._ports[name] = p

--- a/rhea/cores/fifo/fifo_async.py
+++ b/rhea/cores/fifo/fifo_async.py
@@ -50,8 +50,8 @@ def fifo_async(clock_write, clock_read, fifobus, reset, size=128):
 
     # sync'd resets, the input reset is more than likely sync'd to one
     # of the clock domains, sync both regardless ...
-    wrst = ResetSignal(reset.active, active=reset.active, async=reset.async)
-    rrst = ResetSignal(reset.active, active=reset.active, async=reset.async)
+    wrst = ResetSignal(reset.active, active=reset.active, isasync=reset.isasync)
+    rrst = ResetSignal(reset.active, active=reset.active, isasync=reset.isasync)
 
     # @todo: if ResetSignal use the active attribute to determine 
     #        if 'not reset' or 'reset'.  If the active==0 then 

--- a/rhea/cores/fifo/fifo_fast.py
+++ b/rhea/cores/fifo/fifo_fast.py
@@ -142,7 +142,7 @@ def fifo_fast(glbl, fifobus, size=16, use_srl_prim=False):
 
 # fifo_fast block attributes, these will affect all instances
 fifo_fast.portmap = dict(
-    reset=ResetSignal(0, active=1, async=False),
+    reset=ResetSignal(0, active=1, isasync=False),
     clock=Signal(bool(0)),
     fbus=FIFOBus()
 )

--- a/rhea/cores/sdram/sdram_sdr.py
+++ b/rhea/cores/sdram/sdram_sdr.py
@@ -75,8 +75,8 @@ def sdram_sdr_controller(clock, reset, ibus, extram, refresh=True):
 # default portmap
 clock = Clock(0, frequency=100e6)
 sdram_sdr_controller.portmap = {
-    'clock': clock, 
-    'reset': ResetSignal(0, active=0, async=False),
+    'clock': clock,
+    'reset': ResetSignal(0, active=0, isasync=False),
     'ibus': None,
     'extmem': SDRAMInterface(clock)
 }

--- a/rhea/cores/usbext/fpgalink/_fl_convert.py
+++ b/rhea/cores/usbext/fpgalink/_fl_convert.py
@@ -83,14 +83,14 @@ def comm_fpga_fx2_v1_stub(
             chanAddr_out.next = True
             h2fData_out.next = 3
             h2fValid_out.next = True
-            f2hReady_out.next = True            
+            f2hReady_out.next = True
 
     return hdl
 
 
 def convert(dir=None):
     clk_in = Signal(bool(0))
-    reset_in = ResetSignal(bool(0), active=0, async=True)
+    reset_in = ResetSignal(bool(0), active=0, isasync=True)
     fx2FifoSel_out = Signal(bool(0))
     #fxData_io
     fx2Data_in = Signal(intbv(0)[8:])

--- a/rhea/cores/usbext/fpgalink/fpgalink_fx2.py
+++ b/rhea/cores/usbext/fpgalink/fpgalink_fx2.py
@@ -13,7 +13,7 @@ def get_interfaces():
     """ Single function to get the buses
     """
     clock = Signal(bool(1))
-    reset = ResetSignal(bool(1), active=0, async=False)
+    reset = ResetSignal(bool(1), active=0, isasync=False)
 
     # Get an object that can be used for the "interfaces"
     fx2bus = Bus()  # External to the FPGA

--- a/rhea/models/usbext/fx2/fx2_model.py
+++ b/rhea/models/usbext/fx2/fx2_model.py
@@ -139,7 +139,7 @@ class Fx2Model(threading.Thread):
         fx2 = Bus()
         fx2.IFCLK = Signal(bool(1))
         (fx2.SLWR, fx2.SLRD, fx2.SLOE) = [Signal(bool(dbl)) for _ in range(3)]
-        fx2.RST = ResetSignal(bool(1), active=0, async=True)
+        fx2.RST = ResetSignal(bool(1), active=0, isasync=True)
         fx2.ADDR = Signal(intbv(0)[2:])
         fx2.FDI, fx2.FDO = [Signal(intbv(0)[8:]) for _ in (1, 2)]
         (fx2.FLAGA, fx2.FLAGB,

--- a/rhea/system/glbl.py
+++ b/rhea/system/glbl.py
@@ -22,7 +22,7 @@ class Global:
             self.clock = clock
         
         if reset is None:            
-            self.reset = Reset(0, active=1, async=False) 
+            self.reset = Reset(0, active=1, isasync=False)
         else:
             self.reset = reset
 

--- a/rhea/system/memmap/avalonmm.py
+++ b/rhea/system/memmap/avalonmm.py
@@ -34,7 +34,7 @@ class AvalonMM(MemoryMapped):
             self.clk = glbl.clock
 
         if glbl.reset is None:
-            self.reset = Reset(0, active=1, async=False)
+            self.reset = Reset(0, active=1, isasync=False)
         else:
             self.reset = glbl.reset
 

--- a/rhea/system/memmap/memmap.py
+++ b/rhea/system/memmap/memmap.py
@@ -123,7 +123,7 @@ class MemoryMapped(MemorySpace):
         _mm_per += 1
 
     @myhdl.block
-    def add(self, memspace, name=''):
+    def add(self, memspace, peripheral_name=''):
         """ add a peripheral register-file to the bus
         """
         assert isinstance(memspace, MemorySpace)
@@ -156,17 +156,17 @@ class MemoryMapped(MemorySpace):
                 if isinstance(v, Register):
                     v.addr += base_address
 
-            if name in self.regfiles:
-                self.names[name] += 1
-                name = name.upper() + "_{:03d}".format(self.names[name])
+            if peripheral_name in self.regfiles:
+                self.names[peripheral_name] += 1
+                peripheral_name = peripheral_name.upper() + "_{:03d}".format(self.names[peripheral_name])
             else:
-                self.names = {name: 0}
-                name = name.upper() + "_000"
+                self.names = {peripheral_name: 0}
+                peripheral_name = peripheral_name.upper() + "_000"
 
-            self.regfiles[name] = arf
+            self.regfiles[peripheral_name] = arf
 
             # return the peripheral generators for this bus
-            g = self.peripheral_regfile(regfile, name)
+            g = self.peripheral_regfile(regfile, peripheral_name)
 
         else:
             if base_address is None:

--- a/rhea/system/memmap/memmap.py
+++ b/rhea/system/memmap/memmap.py
@@ -40,7 +40,7 @@ class MemoryMapped(MemorySpace):
 
         if glbl is None:
             self.clock = Clock(bool(0))
-            self.reset = Reset(0, active=1, async=False)
+            self.reset = Reset(0, active=1, isasync=False)
         else:
             self.clock, self.reset = glbl.clock, glbl.reset
 

--- a/rhea/system/reset.py
+++ b/rhea/system/reset.py
@@ -4,7 +4,7 @@ from myhdl import delay
 
 
 class Reset(myhdl.ResetSignal):
-    def __init__(self, val, active, async):
+    def __init__(self, val, active, isasync):
         """ Reset signal
         This is a thin wrapper around the myhdl.ResetSignal to
         provide the generator ``pulse`` that is often used in
@@ -13,10 +13,10 @@ class Reset(myhdl.ResetSignal):
         Arguments:
             val (int, bool): default value of the reset signal
             active (int, bool): active state, when is reset active
-            async (bool): asynchronous reset or not
+            isasync (bool): asynchronous reset or not
 
         """
-        super(Reset, self).__init__(val, active, async)
+        super(Reset, self).__init__(val, active, isasync)
 
     def pulse(self, delays=10):
         if isinstance(delays, int):

--- a/rhea/vendor/altera/device_clock_mgmt.py
+++ b/rhea/vendor/altera/device_clock_mgmt.py
@@ -19,8 +19,8 @@ def device_clock_mgmt(clkmgmt):
     # type attached to the interface.  If the interface does not
     # have a reset create a static "no reset".  Reset syncros
     # are handled external to this module
-    reseti = Reset(0, active=1, async=True)
-    reset = Reset(0, active=1, async=True)
+    reseti = Reset(0, active=1, isasync=True)
+    reset = Reset(0, active=1, isasync=True)
     stuck_reset = False
     if clkmgmt.reset is None:
         stuck_reset = True

--- a/rhea/vendor/clock_mgmt.py
+++ b/rhea/vendor/clock_mgmt.py
@@ -26,7 +26,7 @@ class ClockManagement(object):
 
         Example usage:
             clockext = Clock(0, frequency=50e6)
-            resetext = Reset(0, active=0, async=True)
+            resetext = Reset(0, active=0, isasync=True)
             clkmgmt = ClockManagement(clockext, resetext,
                                       output_frequencies=(150e6, 200e6))
             clkmgmt.model = brd.fpga

--- a/rhea/vendor/xilinx/device_clock_mgmt.py
+++ b/rhea/vendor/xilinx/device_clock_mgmt.py
@@ -22,8 +22,8 @@ def device_clock_mgmt(clkmgmt):
     # type attached to the interface.  If the interface does not 
     # have a reset create a state "no reset")\.  Reset syncros 
     # are handled external to this module
-    reseti = Reset(0, active=1, async=True)
-    reset = Reset(0, active=1, async=True)
+    reseti = Reset(0, active=1, isasync=True)
+    reset = Reset(0, active=1, isasync=True)
 
     # Prevent phantom conversion warnings about these signals not
     # being driven or read.  (They escape via clock_management_verilog_code)

--- a/test/test_cores/test_comm/test_prbs.py
+++ b/test/test_cores/test_comm/test_prbs.py
@@ -15,7 +15,7 @@ from rhea.utils.test import run_testbench, tb_args, tb_default_args
 def test_known_prbs5(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     prbs = Signal(intbv(0)[8:])
 
@@ -50,7 +50,7 @@ def test_known_prbs5(args=None):
 def test_known_prbs7(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     prbs = Signal(intbv(0)[8:])
 
@@ -83,7 +83,7 @@ def test_known_prbs7(args=None):
 def test_prbs_word_lengths(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     prbs = Signal(intbv(0)[8:])
 
@@ -119,7 +119,7 @@ def test_prbs_check(args=None):
     order = 9
 
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     prbs = Signal(intbv(0)[8:])
     locked = Signal(bool(0))
@@ -202,7 +202,7 @@ def test_prbs_check(args=None):
 def test_conversion(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=125e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     prbs = Signal(intbv(0)[8:])
 

--- a/test/test_cores/test_converters/test_adc128s022.py
+++ b/test/test_cores/test_converters/test_adc128s022.py
@@ -15,7 +15,7 @@ from rhea.utils.test import run_testbench
 def test_adc128s022():
     
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     glbl = Global(clock, reset)
     fifobus = FIFOBus(width=16)
     spibus = SPIBus()

--- a/test/test_cores/test_elink/test_emesh_fifo.py
+++ b/test/test_cores/test_elink/test_emesh_fifo.py
@@ -21,7 +21,7 @@ def test_emesh_fifo(args=None):
     args = tb_default_args(args)
 
     clock_a, clock_b = Signal(bool(0)), Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=False)
+    reset = ResetSignal(0, active=1, isasync=False)
     emesh_a, emesh_b = EMesh(clock_a), EMesh(clock_b)
     input_data, output_data = [], []
 

--- a/test/test_cores/test_fifo/test_fifo_async.py
+++ b/test/test_cores/test_fifo/test_fifo_async.py
@@ -87,7 +87,7 @@ def test_async_fifo(args=None):
     if args is None:
         args = Namespace(width=8, size=16, name='test')
     
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     wclk = Clock(0, frequency=22e6)
     rclk = Clock(0, frequency=50e6)
     fbus = FIFOBus(width=args.width)
@@ -156,7 +156,7 @@ def test_(args=None):
     if args is None:
         args = Namespace(width=8, size=16, name='test')
 
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     wclk = Clock(0, frequency=22e6)
     rclk = Clock(0, frequency=50e6)
     fbus = FIFOBus(width=args.width)
@@ -195,7 +195,7 @@ def bench_conversion_fifo_async():
     args = Namespace(width=8, size=32, fifosize=64, name='test')
 
     clock_write, clock_read = Signals(bool(0), 2)
-    reset = ResetSignal(0, active=1, async=False)
+    reset = ResetSignal(0, active=1, isasync=False)
 
     fbus = FIFOBus(width=args.width)
     fifosize = args.fifosize

--- a/test/test_cores/test_fifo/test_fifo_fast.py
+++ b/test/test_cores/test_fifo/test_fifo_fast.py
@@ -28,7 +28,7 @@ def test_fifo_fast(args=None):
     """ verify the synchronous FIFO
     """
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
 
     if args is None:
         args = Namespace(width=8, size=16, name='test')
@@ -112,7 +112,7 @@ def test_fifo_fast(args=None):
 def test_overflow_ffifo(args=None):
     """ verify the synchronous FIFO
     """
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     clock = Signal(bool(0))
 
     if args is None:
@@ -197,7 +197,7 @@ def test_overflow_ffifo(args=None):
 def test_underflow_fifo_fast(args=None):
     """ verify the synchronous FIFO
     """
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     clock = Signal(bool(0))
 
     if args is None:
@@ -295,7 +295,7 @@ def test_rw_ffifo(args=None):
     unchanged.
     """
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
 
     if args is None:
         args = Namespace(width=8, size=16, name='test')

--- a/test/test_cores/test_fifo/test_fifo_mem.py
+++ b/test/test_cores/test_fifo/test_fifo_mem.py
@@ -203,7 +203,7 @@ def fifo_mem_wrapper(clock, reset, datain, div, dataout, dorq):
 @myhdl.block
 def bench_fifo_mem_wrapper():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     div, dorq = Signal(bool(0)), Signal(bool(0))
     datain, dataout = Signal(intbv(0)[8:0]), Signal(intbv(0)[8:0])
 

--- a/test/test_cores/test_fifo/test_fifo_ramp.py
+++ b/test/test_cores/test_fifo/test_fifo_ramp.py
@@ -24,7 +24,7 @@ from rhea.utils.test import skip_long_sim_test
 def test_fifo_ramp(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     regbus = Wishbone(glbl)
     fifobus = FIFOBus()

--- a/test/test_cores/test_fifo/test_fifo_sync.py
+++ b/test/test_cores/test_fifo/test_fifo_sync.py
@@ -31,7 +31,7 @@ def test_fifo_sync(args=None):
         assert hasattr(args, 'size')
     args = tb_default_args(args)
 
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     clock = Clock(0, frequency=50e6)
     glbl = Global(clock, reset)
     fbus = FIFOBus(width=args.width)
@@ -112,7 +112,7 @@ def test_fifo_sync_random():
 @myhdl.block
 def bench_convserion_fifo_sync():
     args = Namespace(width=8, size=16, name='test')
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
     clock = Signal(bool(0))
     glbl = Global(clock, reset)
     fbus = FIFOBus(width=args.width)

--- a/test/test_cores/test_misc/test_serio.py
+++ b/test/test_cores/test_misc/test_serio.py
@@ -15,7 +15,7 @@ def test(args=None):
         args = Namespace(trace=False)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     sdi, sdo = Signals(bool(0), 2)
 
     pin = Signals(intbv(0)[16:0], 1)
@@ -65,7 +65,7 @@ def test(args=None):
 
 def test_conversion():
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     sdi, sdo = Signals(bool(0), 2)
 
     # a top-level conversion stub

--- a/test/test_cores/test_misc/test_ticks.py
+++ b/test/test_cores/test_misc/test_ticks.py
@@ -17,7 +17,7 @@ def test_ticks(args=None):
     hticks = 5
 
     clock = Clock(0, frequency=10e3)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     glbl = Global(clock, reset)
 
     @myhdl.block

--- a/test/test_cores/test_sdram/test_sdram.py
+++ b/test/test_cores/test_sdram/test_sdram.py
@@ -28,7 +28,7 @@ def test_sdram(args=None):
     
     # internal clock
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
 
     # sdram clock
     clock_sdram = Clock(0, frequency=100e6)

--- a/test/test_cores/test_spi/test_spi_controller.py
+++ b/test/test_cores/test_spi/test_spi_controller.py
@@ -25,7 +25,7 @@ from rhea.utils.test import run_testbench, tb_convert, tb_args, tb_default_args
 
 # global signals used by many
 clock = Clock(0, frequency=100e6)
-reset = Reset(0, active=1, async=True)
+reset = Reset(0, active=1, isasync=True)
 glbl = Global(clock, reset)
 portmap = dict(
     glbl=glbl,
@@ -61,7 +61,7 @@ def spi_controller_top(clock, reset, sck, mosi, miso, ss):
 def convert():
     """convert the faux-top-level"""
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     sck, mosi, miso, ss = Signals(bool(0), 4)
     inst = spi_controller_top(clock, reset, sck, mosi, miso, ss)
     tb_convert(inst)
@@ -71,7 +71,7 @@ def test_spi_controller_cso(args=None):
     args = tb_default_args(args)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     spibus = SPIBus()
 
@@ -167,7 +167,7 @@ def test_spi_memory_mapped(args=None):
     
     base_address = ba = 0x400
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     regbus = Wishbone(glbl)    
     fifobus = FIFOBus(size=16)

--- a/test/test_cores/test_spi/test_spi_slave.py
+++ b/test/test_cores/test_spi/test_spi_slave.py
@@ -14,7 +14,7 @@ from rhea.utils.test import run_testbench, tb_default_args, tb_args
 def test_spi_slave(args=None):
     args = tb_default_args(args)
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     spibus, fifobus = SPIBus(), FIFOBus()
 

--- a/test/test_cores/test_uart/test_uartlite.py
+++ b/test/test_cores/test_uart/test_uartlite.py
@@ -20,7 +20,7 @@ def test_uart_model(args=None):
     # @todo: get numbytes from args
     numbytes = 7
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     glbl = Global(clock, reset)
     si, so = Signal(bool(1)), Signal(bool(1))
     uartmdl = UARTModel()
@@ -69,7 +69,7 @@ def test_uart(args=None):
     # @todo: get numbytes from args
     numbytes = 13
     clock = Clock(0, frequency=12e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     glbl = Global(clock, reset)
     mdlsi, mdlso = Signal(bool(1)), Signal(bool(1))
     uartmdl = UARTModel()

--- a/test/test_cores/test_video/mm_lt24lcdsys.py
+++ b/test/test_cores/test_video/mm_lt24lcdsys.py
@@ -41,7 +41,7 @@ def mm_lt24lcdsys(clock, reset,
 
 def convert():
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     lcd_on = Signal(bool(0))
     lcd_resetn = Signal(bool(0))
     lcd_csn = Signal(bool(0))

--- a/test/test_cores/test_video/mm_vgasys.py
+++ b/test/test_cores/test_video/mm_vgasys.py
@@ -58,7 +58,7 @@ def convert(color_depth=(8, 8, 8,)):
     """ convert the vgasys to verilog
     """
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     vselect = Signal(bool(0))
 
     hsync = Signal(bool(0))

--- a/test/test_cores/test_video/test_lt24lcd_driver.py
+++ b/test/test_cores/test_video/test_lt24lcd_driver.py
@@ -17,7 +17,7 @@ from rhea.utils.test import run_testbench, tb_default_args
 @myhdl.block
 def bench_lt24lcd_driver():
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     lcd = LT24Interface()
     display = LT24LCDDisplay()

--- a/test/test_cores/test_video/test_lt24lcdsys.py
+++ b/test/test_cores/test_video/test_lt24lcdsys.py
@@ -21,7 +21,7 @@ def test_lt24lcd(args=None):
     args = tb_default_args(args)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=True)
+    reset = Reset(0, active=0, isasync=True)
     glbl = Global(clock, reset)
 
     lcd_on = Signal(bool(0))

--- a/test/test_cores/test_video/test_vgasys.py
+++ b/test/test_cores/test_video/test_vgasys.py
@@ -36,7 +36,7 @@ def test_vgasys(args=None):
     args = tb_default_args(args)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=0, async=False)
+    reset = Reset(0, active=0, isasync=False)
     vselect = Signal(bool(0))
 
     # interface to the VGA driver and emulated display

--- a/test/test_cosim/test_fpgalink/test_fpgalink.py
+++ b/test/test_cosim/test_fpgalink/test_fpgalink.py
@@ -82,9 +82,9 @@ def map_ext_int(clock, reset, fx2_ext, fx2_bus):
             sFDO.next = FDO
 
     return tb_assign, tb_monitor
-        
 
-@pytest.skip(msg="not working and not used")
+
+@pytest.mark.skip(msg="not working and not used")
 def test_fpgalink():
     args = argparse.Namespace(cosim=False)
     args.vcd = tb_clean_vcd('fpgalink_fx2')

--- a/test/test_system/regfilesys.py
+++ b/test/test_system/regfilesys.py
@@ -56,7 +56,7 @@ def memmap_component(glbl, csrbus, cio, user_regfile=None):
     else:
         regfile = user_regfile
         
-    regfile_inst = csrbus.add(glbl, regfile, name='TESTREG')
+    regfile_inst = csrbus.add(glbl, regfile, peripheral_name='TESTREG')
 
     @always_comb
     def beh_assign():

--- a/test/test_system/test_memmap.py
+++ b/test/test_system/test_memmap.py
@@ -16,7 +16,7 @@ def testbench_memmap(args=None):
     args = tb_default_args(args)
 
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     csbus = Barebone(glbl, data_width=8, address_width=16)
 

--- a/test/test_system/test_memmap_command_bridge.py
+++ b/test/test_system/test_memmap_command_bridge.py
@@ -54,7 +54,7 @@ def test_memmap_command_bridge(args=None):
     nloops = 37
     args = tb_default_args(args)
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     fifobus = FIFOBus()
     memmap = Barebone(glbl, data_width=32, address_width=28)

--- a/test/test_system/test_regfile.py
+++ b/test/test_system/test_regfile.py
@@ -81,7 +81,7 @@ def peripheral_top(clock, reset, mon):
 def memmap_peripheral(glbl, regbus, mon):
     global regfile
     regfile = create_regfile()
-    regfile_inst = regbus.add(regfile, name='test1')
+    regfile_inst = regbus.add(regfile, peripheral_name='test1')
 
     return regfile_inst
 
@@ -92,7 +92,7 @@ def memmap_peripheral_bits(glbl, regbus, mon):
 
     clock, reset = glbl.clock, glbl.reset
     regfile = create_regfile()
-    regfile_inst = regbus.add(regfile, name='test2')
+    regfile_inst = regbus.add(regfile, peripheral_name='test2')
     count = modbv(0, min=0, max=1)
 
     @always(clock.posedge)

--- a/test/test_system/test_regfile.py
+++ b/test/test_system/test_regfile.py
@@ -128,7 +128,7 @@ def test_register_file(args=None):
 
     # top-level signals and interfaces
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     regbus = Wishbone(glbl) 
 
@@ -190,7 +190,7 @@ def test_register_file_bits():
     global regfile
     # top-level signals and interfaces
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     regbus = Wishbone(glbl) 
 
@@ -234,7 +234,7 @@ def test_register_file_bits():
 
 def test_convert():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     mon = Signal(intbv(0)[8:])
     inst = peripheral_top(clock, reset, mon)
     tb_convert(inst)

--- a/test/test_system/test_streamers.py
+++ b/test/test_system/test_streamers.py
@@ -113,7 +113,7 @@ def testbench_streamer(args=None):
         args.bustype = 'barebone'
 
     clock = Clock(0, frequency=100e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
 
     # @todo: support all stream types ...

--- a/test/test_system/test_to_generic.py
+++ b/test/test_system/test_to_generic.py
@@ -19,7 +19,7 @@ busmap = {'barebone': Barebone,
           'axi': AXI4Lite}
 
 
-pytest.skip(msg="simulator crashes, duplicate error, causes next to fail")
+@pytest.mark.skip(msg="simulator crashes, duplicate error, causes next to fail")
 def testbench_to_generic(args=None):
     """ Test memory-mapped bus and the mapping to a generic bus
 
@@ -37,7 +37,7 @@ def testbench_to_generic(args=None):
         args.num_loops = 10
 
     clock = Clock(0, frequency=100e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
 
     if hasattr(args, 'bustype'):
@@ -98,7 +98,7 @@ def test_barebone():
     testbench_to_generic(argparse.Namespace(bustype='barebone'))
 
 
-pytest.skip(msg="simulator crashes, duplicate error, causes next to fail")
+@pytest.mark.skip(msg="simulator crashes, duplicate error, causes next to fail")
 def test_wishbone():
     testbench_to_generic(argparse.Namespace(bustype='wishbone'))
 

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -37,7 +37,7 @@ def testbench_nameofwhatsbeingtested(args=None):
     # create signals, models, etc. that are needed for the various
     # stimulus (a testbench may have multiple stimulus tests).
     clock = Clock(0, frequency=50e6)
-    reset = Reset(0, active=1, async=False)
+    reset = Reset(0, active=1, isasync=False)
     glbl = Global(clock, reset)
     
     sigin = Signal(intbv(0)[8:])

--- a/test/test_vendor/test_device_clock_mgmt.py
+++ b/test/test_vendor/test_device_clock_mgmt.py
@@ -64,7 +64,7 @@ def test_device_clock_mgmt(args=None):
     if not hasattr(args, 'vendor'):
         args.vendor = 'altera'
     clockext = Clock(0, frequency=50e6)
-    resetext = ResetSignal(0, active=0, async=True)
+    resetext = ResetSignal(0, active=0, isasync=True)
     dripple = Signal(bool(0))
     status = Signal(intbv(0)[4:])
 


### PR DESCRIPTION
This changes **async** to **isasync** because async is a reserved keyword in Python 3.7. Also, now it's compatible with the latest version of myhdl